### PR TITLE
Updating Unbound grep example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you do get an error you need to do some "bug hunting". I advice that you use 
 For the Unbound block list you can catch any line with wrong syntax using:
 
 ```
-# grep -rn '^local-zone: "*" always_nxdomain$' unbound-blocked-hosts.conf | more
+# grep -nv '^local-zone: ".*" always_nxdomain$' unbound-blocked-hosts.conf | more
 ```
 
 You can also check the dnsmasq block list for any lines that, for example, doesn't begin with 0.0.0.0:


### PR DESCRIPTION
Why '-r' in trouble shooting greps?  Since you're giving it a file it will only
search that right?
Can also probably remove 'r' from dnsmasq one but I don't use so I couldn't test to be sure.